### PR TITLE
[FIX] NEW 조회 API 데이터의 개수가 적을때의 문제점 해결

### DIFF
--- a/components/boxes/PostsBox.tsx
+++ b/components/boxes/PostsBox.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import useAllPosts from '../../hooks/useAllPosts';
 import PostBox from './PostBox';
 import Loading from '../../app/loading';
@@ -14,15 +14,13 @@ export default function PostsBox() {
   const category = getArchivePath[path].result;
   const layoutNum = useSelector(selectNumberOfBoxes);
   const size = getPostsNumber[layoutNum].number;
-  const { postsData, fetchMorePosts } = useAllPosts(category, size);
+  const { postsData, fetchMorePosts, isLast } = useAllPosts(category, size);
   const bottomRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    console.log('layoutNum changed:', layoutNum);
     const currentRef = bottomRef.current;
     const observer = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting) {
-        console.log('Bottom ref is intersecting', entries);
+      if (entries[0].isIntersecting && !isLast) {
         fetchMorePosts();
       }
     }, {
@@ -31,23 +29,22 @@ export default function PostsBox() {
 
     if (currentRef) {
       observer.observe(currentRef);
-      console.log('Observer started observing', currentRef);
     }
 
     return () => {
       if (currentRef) {
         observer.unobserve(currentRef);
-        console.log('Observer stopped observing', currentRef);
       }
     };
-  }, [fetchMorePosts, layoutNum]);
+  }, [fetchMorePosts, layoutNum, isLast]);
 
-  const itemsToRender = postsData ? postsData.slice(0, postsData.length - (postsData.length % layoutNum)) : [];
+  const itemsToRender = postsData 
+    ? (postsData.length <= layoutNum ? postsData : postsData.slice(0, postsData.length - (postsData.length % layoutNum))) 
+    : [];
 
   return (
     <div
       className='outBox relative flex h-full flex-wrap items-center gap-[0.7%] overflow-auto overflow-y-scroll transition-all'
-      onScroll={() => console.log('Scrolling...')}
     >
       {postsData ?
         itemsToRender.map((item, index) => (
@@ -64,7 +61,7 @@ export default function PostsBox() {
         :
         <Loading />
       }
-      <div ref={bottomRef} className='bottom-0 h-[2px] w-full'></div>
+      <div ref={bottomRef} className='bottom-0 h-[1px] w-full'></div>
     </div>
   );
 }

--- a/hooks/useAllPosts.ts
+++ b/hooks/useAllPosts.ts
@@ -25,7 +25,6 @@ const useAllPosts = (category: string, size: number) => {
       if (data) {
         setPostsData(prev => [...prev, ...data.data.postSummaryList.content]);
         setOldestPostId(data.data.oldestPostId);
-        console.log(data.data.oldestPostId);
         setIsLast(data.data.postSummaryList.last);
       } else {
         console.log('No data received');
@@ -43,7 +42,7 @@ const useAllPosts = (category: string, size: number) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [category]);
 
-  return { postsData, fetchMorePosts };
+  return { postsData, fetchMorePosts, isLast };
 };
 
 export default useAllPosts;


### PR DESCRIPTION
가져오는 데이터의 수가 layoutNum보다 적을 때 문제가 발생했으며, 해당 문제 부분은 조건문의 변경과 isLast data를 활용하여 문제 해결하였습니다. 다만, 데이터가 없을때 예를들어서 가져오는 데이터의 개수가 0일때 문제점은 백엔드와 논의를 해야하는 상황입니다.