### PR TITLE
[FEAT] 토글/슬라이드 그림자 추가, 옵션모달ON일때 토글 다크보라 색상 유지, 중복검색X, 연관검색어 클릭시 마지막 단어에 적용..

### DIFF
--- a/api/search/getSearch.ts
+++ b/api/search/getSearch.ts
@@ -23,24 +23,33 @@ export async function getUserSearchResults(keyword: string) {
   }
 }
 
-export async function getTagSearchResults(keyword: string) {
-  const url = `${process.env.NEXT_PUBLIC_API_URL}/search/tags?keyword=${keyword}`;
-
+export async function getTagSearchResults(keywords: string[]) {
   try {
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      credentials: 'include',
-    });
+    const promises = keywords.map((keyword) =>
+      fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/search/tags?keyword=${encodeURIComponent(keyword)}`,
+        {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include',
+        },
+      ),
+    );
+    const responses = await Promise.all(promises);
+    const dataArr = await Promise.all(responses.map((res) => res.json()));
 
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
+    const combinedResults = dataArr.reduce((acc, data) => {
+      if (data && data.data.length > 0) {
+        acc.push(...data.data);
+      }
+      return acc;
+    }, []);
 
-    const data = await response.json();
-    return data;
+    console.log('API 응답 데이터:', combinedResults);
+
+    return combinedResults;
   } catch (error) {
     console.error('Error fetching tag search results:', error);
     alert('태그 검색 중 오류가 발생했습니다. 나중에 다시 시도해 주세요.');

--- a/app/(root)/(menubar-exist)/post/[postId]/components/CommentOptions.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/CommentOptions.tsx
@@ -31,7 +31,10 @@ export default function CommentOptions({
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (optionsRef.current && !optionsRef.current.contains(event.target as Node)) {
+      if (
+        optionsRef.current &&
+        !optionsRef.current.contains(event.target as Node)
+      ) {
         onClose();
       }
     };
@@ -49,21 +52,21 @@ export default function CommentOptions({
   return (
     <div
       ref={optionsRef}
-      className="Options-box absolute right-0 top-0 mt-2 w-auto rounded-xl bg-white p-2 opacity-75 shadow-lg"
+      className="Options-box absolute right-0 top-0 mr-5 mt-2 w-auto rounded-xl bg-white p-2 opacity-75 shadow-lg"
     >
       {isOwnComment ? (
         <div className="box-one">
           <button
             onClick={onEditClick}
             className="text-gray-700 hover:bg-gray-100 text-14px-normal-dP 
-            block w-auto text-center p-1 hover:text-purple whitespace-nowrap"
+            block w-auto whitespace-nowrap p-1 text-center hover:text-purple"
           >
             댓글 수정하기
           </button>
           <button
             onClick={onDeleteClick}
             className="text-gray-700 hover:bg-gray-100 text-14px-normal-dP 
-            block w-auto text-center p-1 hover:text-red whitespace-nowrap"
+            block w-auto whitespace-nowrap p-1 text-center hover:text-red"
           >
             댓글 삭제하기
           </button>
@@ -72,15 +75,15 @@ export default function CommentOptions({
         <div className="box-two">
           <button
             onClick={onReportClick}
-              className="text-gray-700 hover:bg-gray-100 text-14px-normal-dP 
-            block w-auto text-center p-1 hover:text-purple whitespace-nowrap"
+            className="text-gray-700 hover:bg-gray-100 text-14px-normal-dP 
+            block w-auto whitespace-nowrap p-1 text-center hover:text-purple"
           >
             이 댓글 신고하기
           </button>
           <button
             onClick={onBlockUserClick}
-              className="text-gray-700 hover:bg-gray-100 text-14px-normal-dP 
-            block w-auto text-center p-1 hover:text-red whitespace-nowrap"
+            className="text-gray-700 hover:bg-gray-100 text-14px-normal-dP 
+            block w-auto whitespace-nowrap p-1 text-center hover:text-red"
           >
             사용자 차단하기
           </button>

--- a/app/(root)/(menubar-exist)/post/[postId]/components/MidContainer.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/MidContainer.tsx
@@ -9,6 +9,14 @@ import BoxCommonButton from '../../../../../../components/ui/BoxCommonButton';
 import GeneralAction from '../../../../../../components/buttons/option-menu/GeneralAction';
 import { useGeneralAction } from '../../../../../../hooks/useGeneralAction';
 import { getPostSharedCount } from '../../../../../../api/post/getPostSharedCount';
+import useLoggedInUserData from '../../../../../../hooks/user/useLoggedInUserData';
+import PlusButton from '../../../../../../components/animations/PlusButton';
+import {
+  setArchivePost,
+  setCommonModal,
+} from '../../../../../../store/slices/modalSlice';
+import { useDispatch, useSelector } from 'react-redux';
+import { selectLoginStatus } from '../../../../../../store/slices/loginSlice';
 
 interface MidContainerProps {
   post: PostsDetailData['data'];
@@ -31,6 +39,7 @@ interface MidContainerProps {
   imageUrl: string;
   searchRecent: string[];
   setSearchRecent: React.Dispatch<React.SetStateAction<string[]>>;
+  saved: boolean;
 }
 
 export default function MidContainer({
@@ -48,6 +57,7 @@ export default function MidContainer({
   imageUrl,
   searchRecent,
   setSearchRecent,
+  saved,
 }: MidContainerProps) {
   const [sharedCount, setSharedCount] = useState<number>(post.sharedCount ?? 0);
   const [boundary, setBoundary] = useState<'ALL' | 'FOLLOW' | 'NONE'>(
@@ -64,6 +74,9 @@ export default function MidContainer({
   const [currentImageUrl, setCurrentImageUrl] = useState(
     post.files[0]?.fileUrl || '',
   );
+  const dispatch = useDispatch();
+  const { userData } = useLoggedInUserData();
+  const isLoggedIn = useSelector(selectLoginStatus);
 
   useEffect(() => {
     const fetchSharedCount = async () => {
@@ -157,7 +170,10 @@ export default function MidContainer({
   }, [imageBoxWidth]);
 
   return (
-    <div ref={containerRef} className="h-screen overflow-y-scroll">
+    <div
+      ref={containerRef}
+      className="flex min-h-[calc(100vh-200px)] flex-col justify-between"
+    >
       <div className="mx-auto my-0 flex w-full flex-col  justify-center">
         <div
           className="BoxWrap sticky flex justify-center   
@@ -186,34 +202,39 @@ export default function MidContainer({
               }))}
               onImageChange={setCurrentImageUrl}
             />
-            <BoxCommonButton
-              onClick={handleToggleClick}
-              type="toggle"
-              width="4px"
-              height="20px"
-              position="top-left"
-              className="p-3"
-              showGeneralAction={showGeneralAction}
-            />
-            {showGeneralAction && (
-              <div ref={boxRef} className=" absolute left-5 top-0 z-20">
-                <GeneralAction
-                  type="post"
-                  postId={postId}
-                  imageUrl={currentImageUrl}
-                  setSharedCount={setSharedCount}
-                  initialBoundary={boundary}
-                  onBoundaryChange={setBoundary}
+
+            {userData?.data?.nickname === post.nickname && (
+              <>
+                <BoxCommonButton
+                  onClick={handleToggleClick}
+                  type="toggle"
+                  width="4px"
+                  height="20px"
+                  position="top-left"
+                  className="p-3"
+                  showGeneralAction={showGeneralAction}
                 />
-              </div>
+                {showGeneralAction && (
+                  <div ref={boxRef} className=" absolute left-5 top-0 z-20">
+                    <GeneralAction
+                      type="post"
+                      postId={postId}
+                      imageUrl={currentImageUrl}
+                      setSharedCount={setSharedCount}
+                      initialBoundary={boundary}
+                      onBoundaryChange={setBoundary}
+                    />
+                  </div>
+                )}
+              </>
             )}
-            <BoxCommonButton
-              onClick={() => console.log('Plus Clicked')}
-              type="plus"
-              width="36px"
-              height="36px"
-              position="bottom-right"
-              className="p-2"
+
+            <PlusButton
+              postId={postId}
+              width="24px"
+              height="24px"
+              isClicked={saved}
+              active={isLoggedIn === 'loggedIn'}
             />
           </div>
           <div
@@ -240,7 +261,11 @@ export default function MidContainer({
               sharedCount={sharedCount}
               setSharedCount={setSharedCount}
             />
-            <PostTags post={post} searchRecent={searchRecent} setSearchRecent={setSearchRecent} />
+            <PostTags
+              post={post}
+              searchRecent={searchRecent}
+              setSearchRecent={setSearchRecent}
+            />
           </div>
           <div>
             <CommentWrap

--- a/app/(root)/(menubar-exist)/post/[postId]/components/TopContainer.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/TopContainer.tsx
@@ -4,7 +4,7 @@ import UserInfo from '../../../../../../components/ui/UserInfo';
 import { PostsDetailData } from '../../../../../../types/dataType';
 import Link from 'next/link';
 import useLoggedInUserData from '../../../../../../hooks/user/useLoggedInUserData';
-import { useRouter } from 'next/navigation';
+import { useGoToProfile } from '../../../../../../hooks/useGoToProfile';
 import {
   followUser,
   unFollowUser,
@@ -23,7 +23,7 @@ export default function TopContainer({ user, postId }: userProps) {
     user.followerCount,
   );
   const [isOwner, setIsOwner] = useState(false);
-  const router = useRouter();
+  const { goToProfile } = useGoToProfile(); 
 
   useEffect(() => {
     if (userData && userData.data.nickname === user.nickname) {
@@ -64,21 +64,13 @@ export default function TopContainer({ user, postId }: userProps) {
   if (!user) {
     return <div>사용자를 찾을 수 없습니다.</div>;
   }
-  //프로필 이동
-  const test = (nickname: string) => {
-    if (nickname !== undefined) {
-      localStorage.setItem("name",nickname)
-      router.push(`/profile/${nickname}`);
-    }
-    console.log('에러');
-  };
 
   return (
     <div className="flex flex-wrap items-center justify-between bg-white p-2">
       <div className="wrap-left flex flex-wrap items-center gap-4">
         <div
           className="cursor-pointer"
-          onClick={(e) => test(user.nickname)}
+          onClick={() => goToProfile(user.nickname)} 
         >
           <UserImage
             src={user.profileUrl}

--- a/app/(root)/(menubar-exist)/post/[postId]/components/bot/ChattingBar.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/bot/ChattingBar.tsx
@@ -6,6 +6,7 @@ import { selectLoginStatus } from '../../../../../../../store/slices/loginSlice'
 import { useSelector } from 'react-redux';
 import useLoggedInUserData from '../../../../../../../hooks/user/useLoggedInUserData';
 import ReplyBar from './ReplyBar';
+import { useGoToProfile } from '../../../../../../../hooks/useGoToProfile';
 
 type ChattingBarProps = {
   onAddComment: (newComment: AddCommentType) => void;
@@ -24,6 +25,7 @@ export default function ChattingBar({
   const [commentContent, setCommentContent] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isLoggedIn = useSelector(selectLoginStatus);
+  const { goToProfile } = useGoToProfile();
 
   useEffect(() => {
     if (replyUser.name) {
@@ -80,6 +82,7 @@ export default function ChattingBar({
             alt={'profileImage'}
             width={40}
             height={40}
+            onClick={() => goToProfile(userData.data.nickname)}
           />
         )}
         <form className="relative h-12 w-full ">

--- a/app/(root)/(menubar-exist)/post/[postId]/components/mid/CommentItem.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/mid/CommentItem.tsx
@@ -16,6 +16,8 @@ import {
   setCommonModal,
 } from '../../../../../../../store/slices/modalSlice';
 import AlarmModal from '../../../../../../../components/modal/common/AlarmModal';
+import { useGoToProfile } from '../../../../../../../hooks/useGoToProfile';
+import useLoggedInUserData from '../../../../../../../hooks/user/useLoggedInUserData';
 
 interface CommentItemProps {
   item: Comment;
@@ -43,6 +45,8 @@ export default function CommentItem({
   const [showOptions, setShowOptions] = useState(false);
   const commentRef = useRef<HTMLDivElement>(null);
   const textarea = useRef<HTMLTextAreaElement>(null);
+  const { goToProfile } = useGoToProfile();
+  const { userData } = useLoggedInUserData();
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -166,7 +170,7 @@ export default function CommentItem({
       >
         <div
           className={`comment-box button-tr group/toggle flex justify-between rounded-xl pb-[10px] pl-[10px] 
-          pt-[10px] hover:bg-darkPurple hover:bg-opacity-20`}
+                pt-[10px] ${showOptions ? 'bg-darkPurple bg-opacity-20' : 'hover:bg-darkPurple hover:bg-opacity-20'}`}
         >
           <div className="flex">
             <div className="mr-3">
@@ -175,6 +179,7 @@ export default function CommentItem({
                 alt="임시이미지"
                 width={40}
                 height={40}
+                onClick={() => goToProfile(item.commentUserNickname)}
               />
             </div>
             <div className="leading-4">
@@ -260,10 +265,13 @@ export default function CommentItem({
               </div>
             </div>
           </div>
-          <div className="relative mr-3 hidden h-full group-hover/toggle:block ">
+          <div
+            className={`relative mr-3 ${showOptions ? 'block' : 'hidden group-hover/toggle:block'}`}
+          >
             <Toggle
-              className="fill-white"
+              className={`${showOptions ? 'fill-darkPurple' : 'fill-white'}`}
               onClick={() => setShowOptions(!showOptions)}
+              showGeneralAction={showOptions}
             />
             {showOptions && (
               <CommentOptions

--- a/app/(root)/(menubar-exist)/post/[postId]/components/mid/PostCount.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/mid/PostCount.tsx
@@ -34,7 +34,7 @@ export default function PostCount({
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  const handleShareCount = useHandleShareCount(postId, setSharedCount);
+  const handleShareCount = useHandleShareCount('post', postId, setSharedCount);
 
   useEffect(() => {
     const fetchLikeCount = async () => {

--- a/app/(root)/(menubar-exist)/post/[postId]/page.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/page.tsx
@@ -48,6 +48,7 @@ export default function PostDetailPage() {
 
   const nickname = userDetail.post?.nickname ?? '';
   const imageUrl = userDetail.post?.files[0]?.fileUrl ?? '';
+  const saved = userDetail.post?.saved ?? false;
 
   return (
     <div className="hide-scrollbar overflow-auto">
@@ -67,8 +68,9 @@ export default function PostDetailPage() {
         isLastPage={commentsData.isLastPage}
         nickname={nickname}
         imageUrl={imageUrl}
-        searchRecent={searchRecent} 
-        setSearchRecent={setSearchRecent} 
+        searchRecent={searchRecent}
+        setSearchRecent={setSearchRecent}
+        saved={saved}
       />
       <BotContainer
         onAddComment={commentsData.handleAddComment}

--- a/app/(root)/(menubar-exist)/search/posts/page.tsx
+++ b/app/(root)/(menubar-exist)/search/posts/page.tsx
@@ -220,6 +220,7 @@ export default function SearchResultsPage() {
                   setIsSuggestLoginModalShow={setIsSuggestLoginModalShow}
                   setSharedCount={setSharedCount}
                   onLikeToggle={() => handleLikeToggle(item.postId)}
+                  isOptional={false}
                 />
               ))}
               <div ref={bottomRef} className="h-[1px] w-full"></div>

--- a/components/bars/TagBar.tsx
+++ b/components/bars/TagBar.tsx
@@ -53,29 +53,15 @@ export default function TagBar({
     setVisibleTags(filteredTags);
   }, [activeTags, searchTerm]);
 
-  useEffect(() => {
-    const handleResize = () => {
-      const maxVisibleTags = Math.floor(window.innerWidth / 130);
-      setVisibleTags((prevTags) => prevTags.slice(0, maxVisibleTags));
-    };
-
-    handleResize();
-    window.addEventListener('resize', handleResize);
-
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, []);
-
   return (
-    <div className="tagBar flex h-[66px] w-full flex-col items-start justify-between px-[5px]">
-      <div className="tagDiv flex h-[53px] w-full items-center justify-between overflow-hidden border-b-[1px] border-navBotSolidGray">
-        <div className="flex gap-[5px] overflow-hidden whitespace-nowrap">
+    <div className="tagBar  flex h-[66px] w-full flex-col items-start justify-between px-[5px]">
+      <div className="tagDiv  flex h-[53px] w-full items-center justify-between overflow-hidden border-b-[1px] border-navBotSolidGray">
+        <div className="flex gap-[5px] overflow-hidden ">
           {visibleTags.map((tag, index) => (
             <button
               key={index}
               onClick={() => onTagClick(tag.name)}
-              className={`hashtag-layout hashtag-hover-active button-tr button-tr-tf flex-shrink-0 items-center justify-center border-none bg-hashTagGray transition-all`}
+              className={`hashtag-layout  hashtag-hover-active button-tr button-tr-tf flex-shrink-0 items-center justify-center border-none bg-hashTagGray transition-all`}
             >
               <p className="text-[14px] font-[700]">{tag.name}</p>
             </button>

--- a/components/buttons/Toggle.tsx
+++ b/components/buttons/Toggle.tsx
@@ -3,27 +3,77 @@ type ToggleProps = {
   width?: string;
   height?: string;
   className?: string;
+  showGeneralAction?: boolean;
 };
 
-const Toggle = ({
-  onClick,
-  width = '10px',
-  height = '20px',
-  className,
-}: ToggleProps) => {
+const Toggle = ({ onClick, className, showGeneralAction }: ToggleProps) => {
   return (
     <svg
-      onClick={onClick}
-      width={width}
-      height={height}
-      viewBox="0 0 4 20"
+      width="13"
+      height="28"
+      viewBox="0 0 13 28"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className={`${className} button-tr hover:fill-purple active:fill-darkPurple stroke-[0.2px] stroke-black`}
+      onClick={onClick}
+      className={`${className} group`}
     >
-      <circle cx="2" cy="2" r="2" />
-      <circle cx="2" cy="10" r="2" />
-      <circle cx="2" cy="18" r="2" />
+      <g filter="url(#filter0_d_549_794)">
+        <circle
+          cx="5.5"
+          cy="5"
+          r="2"
+          className={`${showGeneralAction ? 'fill-darkPurple' : 'fill-white group-hover:fill-purple group-active:fill-darkPurple'}`}
+        />
+        <circle
+          cx="5.5"
+          cy="13"
+          r="2"
+          className={`${showGeneralAction ? 'fill-darkPurple' : 'fill-white group-hover:fill-purple group-active:fill-darkPurple'}`}
+        />
+        <circle
+          cx="5.5"
+          cy="21"
+          r="2"
+          className={`${showGeneralAction ? 'fill-darkPurple' : 'fill-white group-hover:fill-purple group-active:fill-darkPurple'}`}
+        />
+      </g>
+      <defs>
+        <filter
+          id="filter0_d_549_794"
+          x="0.5"
+          y="0"
+          width="12"
+          height="28"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset dx="1" dy="1" />
+          <feGaussianBlur stdDeviation="2" />
+          <feComposite in2="hardAlpha" operator="out" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"
+          />
+          <feBlend
+            mode="normal"
+            in2="BackgroundImageFix"
+            result="effect1_dropShadow_549_794"
+          />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect1_dropShadow_549_794"
+            result="shape"
+          />
+        </filter>
+      </defs>
     </svg>
   );
 };

--- a/components/buttons/option-menu/GeneralAction.tsx
+++ b/components/buttons/option-menu/GeneralAction.tsx
@@ -181,7 +181,11 @@ export default function GeneralAction({
     type === 'archive' ? archiveActionElements : postActionElements;
 
   return (
-    <div className="text-14px-normal-dP absolute z-40 bg-white ml-2 mt-3 w-[120px] whitespace-nowrap rounded-xl bg-opacity-90 py-[13px] shadow-option-modal-shadow">
+    <div
+      className={`text-14px-normal-dP absolute z-40 bg-white 
+    ${type !== 'archive' ? 'ml-5' : 'ml-2'} mt-3 w-[120px] whitespace-nowrap 
+    rounded-xl bg-opacity-90 py-[13px] shadow-option-modal-shadow`}
+    >
       {actionElements.map((item, index) => {
         const IconComponent = Icons[item.icon as keyof typeof Icons];
         const handleClick = item.label.includes('설정')
@@ -201,7 +205,8 @@ export default function GeneralAction({
           <div
             key={index}
             onClick={handleClick}
-            className="flex cursor-pointer items-center justify-center rounded-xl px-2 pb-[10px] hover:font-bold"
+            className="flex cursor-pointer items-center justify-center 
+            rounded-xl px-2 pb-[10px] hover:font-bold"
           >
             {item.label.includes('수정') ? (
               <Link href={`/post/edit/${postId}`} className="flex items-center">

--- a/components/buttons/option-menu/GeneralSetting.tsx
+++ b/components/buttons/option-menu/GeneralSetting.tsx
@@ -8,7 +8,7 @@ import { patchArchiveBoundary } from '../../../api/archive/patchArchiveBoundary'
 interface GeneralSettingProps {
   type: 'archive' | 'post';
   postId?: number;
-  archiveId?: number; 
+  archiveId?: number;
   onBack: () => void;
   initialBoundary: 'ALL' | 'FOLLOW' | 'NONE';
   onBoundaryChange: (newBoundary: 'ALL' | 'FOLLOW' | 'NONE') => void;
@@ -23,7 +23,9 @@ export default function GeneralSetting({
   initialBoundary,
   onBoundaryChange,
 }: GeneralSettingProps) {
-  const [selected, setSelected] = useState<'ALL' | 'FOLLOW' | 'NONE'>(initialBoundary);
+  const [selected, setSelected] = useState<'ALL' | 'FOLLOW' | 'NONE'>(
+    initialBoundary,
+  );
 
   const handleSettingChange = async (newSetting: 'ALL' | 'FOLLOW' | 'NONE') => {
     setSelected(newSetting);
@@ -47,9 +49,9 @@ export default function GeneralSetting({
   };
 
   const boundaryMap: { [key: string]: 'ALL' | 'FOLLOW' | 'NONE' } = {
-    '전체공개': 'ALL',
-    '팔로워공개': 'FOLLOW',
-    '비공개': 'NONE',
+    전체공개: 'ALL',
+    팔로워공개: 'FOLLOW',
+    비공개: 'NONE',
   };
 
   const items = settingElements.map((item) => ({
@@ -59,8 +61,10 @@ export default function GeneralSetting({
   }));
 
   return (
-    <div className="text-14px-normal-dP absolute z-10 mt-3 ml-2 w-[120px] 
-    whitespace-nowrap rounded-xl bg-white bg-opacity-90 py-2 shadow-option-modal-shadow">
+    <div
+      className={`text-14px-normal-dP absolute z-10 mt-3  ${type !== 'archive' ? 'ml-5' : 'ml-2'} w-[120px] 
+    whitespace-nowrap rounded-xl bg-white bg-opacity-90 py-2 shadow-option-modal-shadow`}
+    >
       <div className="flex items-center px-3 text-lg font-bold">
         <button onClick={onBack} className="mr-2">
           <MenuBack />

--- a/components/ui/BoxCommonButton.tsx
+++ b/components/ui/BoxCommonButton.tsx
@@ -4,7 +4,7 @@ import PlusButton from '../animations/PlusButton';
 import Toggle from '../buttons/Toggle';
 
 interface ButtonProps {
-  onClick: (e:any) => void;
+  onClick: (e: any) => void;
   showType?: string;
   type: 'heart' | 'plus' | 'toggle';
   isClicked?: boolean;
@@ -39,13 +39,22 @@ const BoxCommonButton: React.FC<ButtonProps> = ({
   className,
 }) => {
   const ButtonComponent = buttonComponents[type];
+
   return (
-    <button onClick={onClick} className={`${showType !== 'list' && 'absolute'} z-10 ${position !== 'nothing' && positionClasses[position]} ${className}`}>
+    <button
+      onClick={onClick}
+      className={`${showType !== 'list' && 'absolute'} z-10 ${position !== 'nothing' && positionClasses[position]} ${className}`}
+    >
       <ButtonComponent
         width={width}
         height={height}
         isClicked={isClicked}
-        className={type === 'toggle' ? `${showGeneralAction ? 'fill-purple' : showType === 'list' ? 'fill-darkPurple' :'fill-white'}` : ''}
+        showGeneralAction={showGeneralAction}
+        className={
+          type === 'toggle'
+            ? `${showGeneralAction ? 'fill-darkPurple' : showType === 'list' ? 'fill-darkPurple' : 'fill-white'}`
+            : ''
+        }
       />
     </button>
   );

--- a/components/ui/UserImage.tsx
+++ b/components/ui/UserImage.tsx
@@ -6,9 +6,10 @@ type UserImageProps = {
   alt: string;
   width?: number;
   height?: number;
+  onClick?: () => void;  
 };
 
-export default function UserImage({ src, alt, width, height }: UserImageProps) {
+export default function UserImage({ src, alt, width, height, onClick }: UserImageProps) {
   return (
     <div
       style={{
@@ -18,15 +19,16 @@ export default function UserImage({ src, alt, width, height }: UserImageProps) {
         overflow: 'hidden',
         borderRadius: '50%',
         flexShrink: 0,
+        cursor: 'pointer', 
       }}
+      onClick={onClick}  
     >
       <Image
         src={src}
         alt={alt}
         sizes="(max-width: 480px) 100vw, (max-width: 768px) 80vw, (max-width: 1024px) 60vw, 40vw"
-        style={{ objectFit: 'cover'}}
+        style={{ objectFit: 'cover' }}
         fill
-        priority={true}
         quality={100}
         className="rounded-full"
       />

--- a/hooks/useGoToProfile.ts
+++ b/hooks/useGoToProfile.ts
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/navigation';
+
+export const useGoToProfile = () => {
+  const router = useRouter();
+
+  const goToProfile = (nickname: string) => {
+    if (nickname !== undefined) {
+      localStorage.setItem("name", nickname);
+      router.push(`/profile/${nickname}`);
+    } else {
+      console.error('닉네임이 없습니다.');
+    }
+  };
+
+  return { goToProfile };
+};

--- a/public/assets/svg/arrow-left.svg
+++ b/public/assets/svg/arrow-left.svg
@@ -1,3 +1,17 @@
-<svg width="25" height="43" viewBox="0 0 25 43" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M20.6413 42.2692C21.5972 43.2251 23.147 43.2251 24.1028 42.2692C25.0587 41.3134 25.0587 39.7636 24.1028 38.8077L6.79515 21.5L24.1028 4.19231C25.0587 3.23643 25.0587 1.68665 24.1028 0.73077C22.724 -0.5121 21.2206 0.212907 20.6413 0.730769L3.33361 18.0385L1.28629 20.0858C0.505236 20.8668 0.505237 22.1332 1.28629 22.9142L3.33361 24.9615L20.6413 42.2692Z" fill="white"/>
+<svg width="25" height="43" viewBox="0 0 25 53" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g filter="url(#filter0_d)">
+    <path d="M20.6413 42.2692C21.5972 43.2251 23.147 43.2251 24.1028 42.2692C25.0587 41.3134 25.0587 39.7636 24.1028 38.8077L6.79515 21.5L24.1028 4.19231C25.0587 3.23643 25.0587 1.68665 24.1028 0.73077C22.724 -0.5121 21.2206 0.212907 20.6413 0.730769L3.33361 18.0385L1.28629 20.0858C0.505236 20.8668 0.505237 22.1332 1.28629 22.9142L3.33361 24.9615L20.6413 42.2692Z" fill="white"/>
+  </g>
+  <defs>
+    <filter id="filter0_d" x="0.180176" y="0.0444336" width="32.1191" height="50.9417" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="4"/>
+      <feGaussianBlur stdDeviation="2"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+  </defs>
 </svg>

--- a/public/assets/svg/arrow-right.svg
+++ b/public/assets/svg/arrow-right.svg
@@ -1,3 +1,17 @@
-<svg width="25" height="43" viewBox="0 0 25 43" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M4.3587 42.2692C3.40282 43.2251 1.85303 43.2251 0.897156 42.2692C-0.0587208 41.3134 -0.0587154 39.7636 0.897162 38.8077L18.2049 21.5L0.897161 4.19231C-0.0587167 3.23643 -0.0587174 1.68665 0.89716 0.73077C2.27599 -0.5121 3.77937 0.212907 4.3587 0.730769L21.6664 18.0385L23.7137 20.0858C24.4948 20.8668 24.4948 22.1332 23.7137 22.9142L21.6664 24.9615L4.3587 42.2692Z" fill="white"/>
+<svg width="33" height="51" viewBox="0 0 33 51" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_3246_881)">
+<path d="M8.3587 42.2692C7.40282 43.2251 5.85303 43.2251 4.89716 42.2692C3.94128 41.3134 3.94128 39.7636 4.89716 38.8077L22.2049 21.5L4.89716 4.19231C3.94128 3.23643 3.94128 1.68665 4.89716 0.73077C6.27599 -0.5121 7.77937 0.212907 8.3587 0.730769L25.6664 18.0385L27.7137 20.0858C28.4948 20.8668 28.4948 22.1332 27.7137 22.9142L25.6664 24.9615L8.3587 42.2692Z" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_d_3246_881" x="0.180176" y="0.0444336" width="32.1191" height="50.9417" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_3246_881"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_3246_881" result="shape"/>
+</filter>
+</defs>
 </svg>

--- a/types/dataType.ts
+++ b/types/dataType.ts
@@ -125,6 +125,7 @@ export type PostsDetailData = {
   success: boolean;
   code: number;
   data: {
+    saved: boolean;
     postId: number;
     nickname: string;
     profileUrl: string;


### PR DESCRIPTION
기존에 있던 feature-mainsearchbar 가 커밋이 꼬여서(해결 계속 안됨) 새로운 브랜치 파서 올립니다.

**토글(점 3개)**
1. 토글 맟 슬라이드에 그림자 추가
2. 옵션모달(토글 클릭 시 나오는)ON일때 토글 다크보라로 색상 유지

**검색바**
1. 중복검색 X
2. 연관검색어 클릭시 마지막 단어에 적용 (ex: 연관 검색어에 있는 '무광' 클릭시 '유광 무' => '유광 무광')
3. 여러개의 키워드 검색 시 연관 검색어에 안뜨는 문제 해결
4. 키워드 칠 때 마다 '모든 키워드 api 요청' 에서 '요청 안보낸 키워드만 api 요청' 으로 변경
5. 검색어 태그들 2 x 5 줄로 고정

**디테일 게시물**
1. 플러스 버튼에 아카이브 추가 기능 적용
2. (아카이브 저장)Saved 값을 userDetail에서 직접 참조하도록 변경
3. 공백 문제 해결 및 레이아웃 개선
3. 프로필 이동(useGoToProfile.ts)hook 생성 및 적용, UserImage에 onClick 옵셔널추가
4. UserImage(댓글, 채팅바)에  프로필 url 적용