### PR TITLE
[FEAT] 디테일 게시물 페이지 개선 및 닉네임 연관검색 추가, [STYLE] z-index 및 버튼 위치 조정

### DIFF
--- a/api/post/getPostSharedCount.ts
+++ b/api/post/getPostSharedCount.ts
@@ -1,10 +1,14 @@
 export async function getPostSharedCount(postId: number): Promise<number> {
   try {
-    const url = new URL(
-      `${process.env.NEXT_PUBLIC_API_URL}/posts/${postId}/shared`,
-    );
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL;
 
-    const response = await fetch(url, {
+    if (!baseUrl) {
+      throw new Error('NEXT_PUBLIC_API_URL is not defined');
+    }
+
+    const url = new URL(`/posts/${postId}/shared`, baseUrl);
+
+    const response = await fetch(url.toString(), {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/api/search/getSearch.ts
+++ b/api/search/getSearch.ts
@@ -15,6 +15,7 @@ export async function getUserSearchResults(keyword: string) {
     }
 
     const data = await response.json();
+    console.log('Fetched data:', data);
     return data;
   } catch (error) {
     console.error('Error fetching search results:', error);

--- a/app/(root)/(menubar-exist)/my-page/page.tsx
+++ b/app/(root)/(menubar-exist)/my-page/page.tsx
@@ -38,7 +38,7 @@ export default function MyPagePage() {
   const [sharedCount, setSharedCount] = useState<number>(0);
   const layoutNum = useSelector(selectNumberOfBoxes);
   const dispatch = useDispatch();
-  const router = useRouter()
+  const router = useRouter();
   const numberOfBoxes = useSelector((state: RootState) =>
     selectNumberOfBoxes(state),
   );
@@ -47,7 +47,7 @@ export default function MyPagePage() {
     if (isLoggedIn === 'loggedOut') {
       return;
     }
-    router.push(`/post/edit/${isTempData[0].postId}`)
+    router.push(`/post/edit/${isTempData[0].postId}`);
   };
 
   const categoryClick = (e: any, category: string) => {
@@ -142,7 +142,7 @@ export default function MyPagePage() {
           </div>
         </div>
       )}
-      <div className={`sticky top-0 z-30 w-full bg-white`}>
+      <div className={`sticky top-0 z-[17] w-full bg-white`}>
         {/* 여기수정 */}
         {/* <CategoryBar elements={myPageCategoryElements} /> */}
         <div className="categoryBar flex h-[66px] w-full flex-col items-start justify-between px-[5px]">
@@ -213,13 +213,13 @@ export default function MyPagePage() {
                   />
                 ) : (
                   <div
-                  key={index}
-                    className="box cursor-pointer relative flex items-center justify-center overflow-hidden rounded-2xl border-[5px] border-transparent p-[5px] transition-all duration-500 hover:border-purple"
+                    key={index}
+                    className="box relative flex cursor-pointer items-center justify-center overflow-hidden rounded-2xl border-[5px] border-transparent p-[5px] transition-all duration-500 hover:border-purple"
                     style={{ width: postBoxWidths[layoutNum] }}
                     onClick={handleTempClick}
                   >
-                    <div className='absolute flex flex-col justify-center w-full h-full bg-lightGray'>
-                      <p className="text-[16px] z-10 text-center ">
+                    <div className="absolute flex h-full w-full flex-col justify-center bg-lightGray">
+                      <p className="z-10 text-center text-[16px] ">
                         임시저장된 게시물
                       </p>
                     </div>

--- a/app/(root)/(menubar-exist)/post/[postId]/components/BotContainer.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/BotContainer.tsx
@@ -12,7 +12,7 @@ interface BotContainerProps {
 // 디테일 게시물 페이지의 하단 영역(채팅바)
 export default function BotContainer({ onAddComment, onAddReply, replyUser, onCancelReply }: BotContainerProps) {
   return (
-    <div className="sticky bottom-0 ">
+    <div className="sticky bottom-0">
       <ChattingBar
         onAddComment={onAddComment}
         onAddReply={onAddReply}

--- a/app/(root)/(menubar-exist)/post/[postId]/components/ImageSlider.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/ImageSlider.tsx
@@ -77,16 +77,16 @@ export default function ImageSlider({
       {/* 좌우 이동 버튼 */}
       {files.length > 1 && (
         <>
-          <div className="pointer-events-none absolute left-0 top-0 z-20 flex h-full w-full items-center justify-between">
+          <div className="pointer-events-none absolute left-0 top-0 z-[15] flex h-full w-full items-center justify-between">
             <button
               onClick={goToPrevious}
-              className="pointer-events-auto z-30 p-2 py-8 pr-8 text-white"
+              className="pointer-events-auto z-[16] p-2 py-8 pr-8 text-white"
             >
               <ArrowLeft />
             </button>
             <button
               onClick={goToNext}
-              className="pointer-events-auto z-30 p-2 py-8 pl-8 text-white"
+              className="pointer-events-auto z-[16] p-2 py-8 pl-8 text-white"
             >
               <ArrowRight />
             </button>
@@ -96,7 +96,7 @@ export default function ImageSlider({
 
       {/* 페이지 인디케이터 */}
       {files.length > 1 && (
-        <div className="pointer-events-none absolute bottom-0 left-0 z-20 flex w-full items-center justify-center p-3">
+        <div className="pointer-events-none absolute bottom-0 left-0 z-[15] flex w-full items-center justify-center p-3">
           {files.map((_, index) => (
             <div
               key={index}

--- a/app/(root)/(menubar-exist)/post/[postId]/components/MidContainer.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/MidContainer.tsx
@@ -219,7 +219,7 @@ export default function MidContainer({
                   showGeneralAction={showGeneralAction}
                 />
                 {showGeneralAction && (
-                  <div ref={boxRef} className=" absolute left-5 top-0 z-20">
+                  <div ref={boxRef} className=" absolute left-3 top-2 z-20">
                     <GeneralAction
                       type="post"
                       onDeleteClick={() => handleDeletePost()}

--- a/app/(root)/(menubar-exist)/post/[postId]/components/MidContainer.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/MidContainer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useEffect, useRef } from 'react';
 import CommentWrap from './mid/CommentWrap';
 import PostCount from './mid/PostCount';
@@ -17,6 +19,8 @@ import {
   selectAlarmModalStatus,
   selectCommonModalStatus,
 } from '../../../../../../store/slices/modalSlice';
+import { deletePost } from '../../../../../../api/post/deletePost';
+import { useRouter } from 'next/navigation';
 
 // 디테일 게시물 페이지의 중간 영역(이미지, 본문, 댓글, 게시물 옵션)
 interface MidContainerProps {
@@ -77,6 +81,7 @@ export default function MidContainer({
   const { userData } = useLoggedInUserData();
   const isLoggedIn = useSelector(selectLoginStatus);
   const { alarmType } = useSelector(selectAlarmModalStatus);
+  const router = useRouter();
 
   useEffect(() => {
     const fetchSharedCount = async () => {
@@ -91,6 +96,19 @@ export default function MidContainer({
 
     fetchSharedCount();
   }, [postId, post.sharedCount]);
+
+  const handleDeletePost = async () => {
+    try {
+      const response = await deletePost(postId);
+      if (response) {
+        alert('게시물이 성공적으로 삭제되었습니다.');
+        router.push('/my-page');
+      }
+    } catch (error) {
+      console.error('게시물 삭제 실패:', error);
+      alert('게시물 삭제에 실패했습니다.');
+    }
+  };
 
   const adjustBoxSize = (deltaY: number) => {
     const newWidth = Math.max(
@@ -204,6 +222,7 @@ export default function MidContainer({
                   <div ref={boxRef} className=" absolute left-5 top-0 z-20">
                     <GeneralAction
                       type="post"
+                      onDeleteClick={() => handleDeletePost()}
                       postId={postId}
                       imageUrl={currentImageUrl}
                       setSharedCount={setSharedCount}

--- a/app/(root)/(menubar-exist)/post/[postId]/components/MidContainer.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/MidContainer.tsx
@@ -13,6 +13,10 @@ import useLoggedInUserData from '../../../../../../hooks/user/useLoggedInUserDat
 import PlusButton from '../../../../../../components/animations/PlusButton';
 import { useSelector } from 'react-redux';
 import { selectLoginStatus } from '../../../../../../store/slices/loginSlice';
+import {
+  selectAlarmModalStatus,
+  selectCommonModalStatus,
+} from '../../../../../../store/slices/modalSlice';
 
 // 디테일 게시물 페이지의 중간 영역(이미지, 본문, 댓글, 게시물 옵션)
 interface MidContainerProps {
@@ -72,6 +76,7 @@ export default function MidContainer({
   );
   const { userData } = useLoggedInUserData();
   const isLoggedIn = useSelector(selectLoginStatus);
+  const { alarmType } = useSelector(selectAlarmModalStatus);
 
   useEffect(() => {
     const fetchSharedCount = async () => {
@@ -120,21 +125,27 @@ export default function MidContainer({
 
   useEffect(() => {
     const handleWheel = (event: WheelEvent) => {
-      adjustBoxSize(event.deltaY);
+      if (!alarmType) {
+        adjustBoxSize(event.deltaY);
+      }
     };
 
     const handleTouchStart = (event: TouchEvent) => {
-      startY.current = event.touches[0].clientY;
+      if (!alarmType) {
+        startY.current = event.touches[0].clientY;
+      }
     };
 
     const handleTouchMove = (event: TouchEvent) => {
-      const deltaY = startY.current - event.touches[0].clientY;
-      const newWidth = Math.max(
-        MIN_WIDTH,
-        Math.min(MAX_WIDTH, imageBoxWidth - deltaY * 0.7),
-      );
-      setImageBoxWidth(newWidth);
-      startY.current = event.touches[0].clientY;
+      if (!alarmType) {
+        const deltaY = startY.current - event.touches[0].clientY;
+        const newWidth = Math.max(
+          MIN_WIDTH,
+          Math.min(MAX_WIDTH, imageBoxWidth - deltaY * 0.7),
+        );
+        setImageBoxWidth(newWidth);
+        startY.current = event.touches[0].clientY;
+      }
     };
 
     window.addEventListener('wheel', handleWheel);
@@ -146,7 +157,7 @@ export default function MidContainer({
       window.removeEventListener('touchstart', handleTouchStart);
       window.removeEventListener('touchmove', handleTouchMove);
     };
-  }, [imageBoxWidth]);
+  }, [imageBoxWidth, alarmType]);
 
   return (
     <div

--- a/app/(root)/(menubar-exist)/post/[postId]/components/MidContainer.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/MidContainer.tsx
@@ -119,12 +119,6 @@ export default function MidContainer({
   };
 
   useEffect(() => {
-    const handleScroll = () => {
-      if (containerRef.current) {
-        setIsScrolledDown(containerRef.current.scrollTop > 0);
-      }
-    };
-
     const handleWheel = (event: WheelEvent) => {
       adjustBoxSize(event.deltaY);
     };
@@ -143,17 +137,11 @@ export default function MidContainer({
       startY.current = event.touches[0].clientY;
     };
 
-    if (containerRef.current) {
-      containerRef.current.addEventListener('scroll', handleScroll);
-    }
     window.addEventListener('wheel', handleWheel);
     window.addEventListener('touchstart', handleTouchStart);
     window.addEventListener('touchmove', handleTouchMove);
 
     return () => {
-      if (containerRef.current) {
-        containerRef.current.removeEventListener('scroll', handleScroll);
-      }
       window.removeEventListener('wheel', handleWheel);
       window.removeEventListener('touchstart', handleTouchStart);
       window.removeEventListener('touchmove', handleTouchMove);
@@ -163,11 +151,11 @@ export default function MidContainer({
   return (
     <div
       ref={containerRef}
-      className="flex min-h-[calc(100vh-245px)] flex-col justify-between"
+      className="flex min-h-[calc(100vh-245px)] flex-col justify-between "
     >
       <div className="top mx-auto my-0 flex w-full flex-grow flex-col justify-center">
         <div
-          className={`BoxWrap sticky mb-[50px] mt-5 flex justify-center 
+          className={`BoxWrap mb-[50px] mt-5 flex justify-center 
               xs:xs:flex-col xs:items-center
               sm:sm:flex-col sm:items-center
               lg:flex-row lg:place-items-stretch

--- a/app/(root)/(menubar-exist)/post/[postId]/components/MidContainer.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/MidContainer.tsx
@@ -11,7 +11,7 @@ import { useGeneralAction } from '../../../../../../hooks/useGeneralAction';
 import { getPostSharedCount } from '../../../../../../api/post/getPostSharedCount';
 import useLoggedInUserData from '../../../../../../hooks/user/useLoggedInUserData';
 import PlusButton from '../../../../../../components/animations/PlusButton';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { selectLoginStatus } from '../../../../../../store/slices/loginSlice';
 
 // 디테일 게시물 페이지의 중간 영역(이미지, 본문, 댓글, 게시물 옵션)
@@ -163,20 +163,15 @@ export default function MidContainer({
   return (
     <div
       ref={containerRef}
-      className="flex min-h-[calc(100vh-200px)] justify-between "
+      className="flex min-h-[calc(100vh-245px)] flex-col justify-between"
     >
-      <div className="mx-auto my-0 flex w-full flex-col  justify-center">
+      <div className="top mx-auto my-0 flex w-full flex-grow flex-col justify-center">
         <div
-          className={`BoxWrap sticky flex justify-center   
-            xs:mb-[45px] xs:mt-[25px] xs:flex-col xs:items-center
-            sm:mb-[40px] sm:mt-[40px] sm:flex-col sm:items-center
-            md:mb-[30px] md:mt-[14px] 
-            lg:mb-[130px] lg:mt-[60px] lg:flex-row lg:place-items-stretch
-            xl:mb-[90px] xl:mt-[55px]
-            2xl:mb-[60px] 2xl:mt-10 
-            3xl:mb-[140px] 3xl:mt-[100px]
-            ${!post.postContent ? 'xs:mb-[100px] xs:mt-[40px] sm:mb-[80px] sm:mt-[40px]  md:mb-[50px] md:mt-[40px] lg:mb-[55px] lg:mt-[30px] ' : ''}
-          `}
+          className={`BoxWrap sticky mb-[50px] mt-5 flex justify-center 
+              xs:xs:flex-col xs:items-center
+              sm:sm:flex-col sm:items-center
+              lg:flex-row lg:place-items-stretch
+        `}
         >
           <div
             className={`ImageBox relative aspect-square rounded-2xl transition-all 
@@ -242,36 +237,41 @@ export default function MidContainer({
             {post.postContent}
           </div>
         </div>
-        <div>
-          <div className="postInfo flex flex-wrap items-center justify-between">
-            <PostCount
-              post={post}
-              postId={postId}
-              toggleScroll={toggleScroll}
-              nickname={nickname}
-              imageUrl={currentImageUrl}
-              sharedCount={sharedCount}
-              setSharedCount={setSharedCount}
-            />
-            <PostTags
-              post={post}
-              searchRecent={searchRecent}
-              setSearchRecent={setSearchRecent}
-            />
-          </div>
-          <div>
-            <CommentWrap
-              user={comments}
-              onLike={onLike}
-              onReply={onReply}
-              onSaveEdit={onSaveEdit}
-              onDelete={onDelete}
-              fetchMoreComments={fetchMoreComments}
-              isLoading={isLoading}
-              isLastPage={isLastPage}
-            />
-          </div>
+        <div className="postInfo mt-auto flex flex-row items-center justify-between">
+          <PostCount
+            post={post}
+            postId={postId}
+            toggleScroll={toggleScroll}
+            nickname={nickname}
+            imageUrl={currentImageUrl}
+            sharedCount={sharedCount}
+            setSharedCount={setSharedCount}
+          />
+          <PostTags
+            post={post}
+            searchRecent={searchRecent}
+            setSearchRecent={setSearchRecent}
+          />
         </div>
+      </div>
+      <div
+        className={`bot overflow-hidden transition-all duration-200 ease-in-out ${
+          imageBoxWidth >= 500
+            ? 'max-h-0 opacity-0'
+            : 'max-h-[1000px] opacity-100'
+        }`}
+        style={{ transitionProperty: 'opacity, max-height' }}
+      >
+        <CommentWrap
+          user={comments}
+          onLike={onLike}
+          onReply={onReply}
+          onSaveEdit={onSaveEdit}
+          onDelete={onDelete}
+          fetchMoreComments={fetchMoreComments}
+          isLoading={isLoading}
+          isLastPage={isLastPage}
+        />
       </div>
     </div>
   );

--- a/app/(root)/(menubar-exist)/post/[postId]/components/MidContainer.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/MidContainer.tsx
@@ -246,6 +246,7 @@ export default function MidContainer({
             imageUrl={currentImageUrl}
             sharedCount={sharedCount}
             setSharedCount={setSharedCount}
+            imageBoxWidth={imageBoxWidth}
           />
           <PostTags
             post={post}

--- a/app/(root)/(menubar-exist)/post/[postId]/components/bot/ChattingBar.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/bot/ChattingBar.tsx
@@ -66,7 +66,7 @@ export default function ChattingBar({
   };
 
   return (
-    <div className="z-9 sticky bottom-0 flex flex-col gap-3 overflow-hidden  bg-white pb-1 pr-1 pt-4 ">
+    <div className=" sticky bottom-0 flex flex-col gap-3 overflow-hidden  bg-white pb-1 pr-1 pt-4 ">
       {replyUser.name && (
         <ReplyBar
           replyTo={`@${replyUser.name} 님에게 댓글 남기는 중...`}

--- a/app/(root)/(menubar-exist)/post/[postId]/components/icons/ThumbsUpIcon.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/icons/ThumbsUpIcon.tsx
@@ -26,20 +26,20 @@ export default function ThumbsUpIcon({
       viewBox="0 0 18 17"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      animate={
-        isClicked
-          ? {
-              rotate: [0, -25, 0],
-              y: [0, -5, 0],
-            }
-          : {
-              opacity: [1, 0.5, 0.7, 0.5, 1],
-            }
-      }
-      transition={{
-        duration: 0.5,
-        ease: [0.42, 0, 0.58, 1],
-      }}
+      // animate={
+      //   isClicked
+      //     ? {
+      //         rotate: [0, -25, 0],
+      //         y: [0, -5, 0],
+      //       }
+      //     : {
+      //         opacity: [1, 0.5, 0.7, 0.5, 1],
+      //       }
+      // }
+      // transition={{
+      //   duration: 0.5,
+      //   ease: [0.42, 0, 0.58, 1],
+      // }}
       style={{ cursor: 'pointer' }}
     >
       <path

--- a/app/(root)/(menubar-exist)/post/[postId]/components/mid/CommentWrap.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/mid/CommentWrap.tsx
@@ -120,10 +120,18 @@ const CommentWrap = ({
       </div>
       <div
         className="comments-wrap max-h-[500px] w-full rounded-2.5xl
-      bg-purple bg-opacity-20  pt-[8px] pb-[8px]
+      bg-purple bg-opacity-20  pb-[8px] pt-[8px]
       transition-all duration-300"
       >
-        <div className="scroll-wrap  mr-3 max-h-[480px] overflow-y-scroll ">
+        <div
+          className="scroll-wrap mr-3 max-h-[480px] overflow-y-scroll"
+          onWheel={(e) => {
+            const scrollTop = e.currentTarget.scrollTop;
+            if (scrollTop > 0 || e.deltaY > 0) {
+              e.stopPropagation();
+            }
+          }}
+        >
           {sortedComments.length > 0 ? (
             sortedComments.map((item, index) => (
               <CommentItem

--- a/app/(root)/(menubar-exist)/post/[postId]/components/mid/CommentWrap.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/mid/CommentWrap.tsx
@@ -99,7 +99,7 @@ const CommentWrap = ({
 
   return (
     <>
-      <div className="flex items-center py-2 pl-4">
+      <div className="flex items-center py-2 pl-4 ">
         <div>
           <p className="mr-5 text-lg font-bold">댓글</p>
         </div>

--- a/app/(root)/(menubar-exist)/post/[postId]/components/mid/PostCount.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/mid/PostCount.tsx
@@ -114,7 +114,7 @@ export default function PostCount({
           />
           {post.commentCount}
         </div>
-        <div className="relative flex items-center" ref={menuRef}>
+        <div className=" flex items-center" ref={menuRef}>
           <PostShareIcon
             className={`mr-2 fill-darkPurple hover:fill-purple active:fill-darkPurple 
             ${isMenuOpen ? 'fill-purple' : ''} `}

--- a/app/(root)/(menubar-exist)/post/[postId]/components/mid/PostCount.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/mid/PostCount.tsx
@@ -114,7 +114,7 @@ export default function PostCount({
           />
           {post.commentCount}
         </div>
-        <div className=" flex items-center" ref={menuRef}>
+        <div className="relative flex items-center" ref={menuRef}>
           <PostShareIcon
             className={`mr-2 fill-darkPurple hover:fill-purple active:fill-darkPurple 
             ${isMenuOpen ? 'fill-purple' : ''} `}

--- a/app/(root)/(menubar-exist)/post/[postId]/components/mid/PostCount.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/mid/PostCount.tsx
@@ -18,6 +18,7 @@ interface PostCountProps {
   imageUrl: string;
   sharedCount: number;
   setSharedCount: React.Dispatch<React.SetStateAction<number>>;
+  imageBoxWidth: number;
 }
 
 // 게시글 좋아요 숫자
@@ -29,6 +30,7 @@ export default function PostCount({
   imageUrl,
   sharedCount,
   setSharedCount,
+  imageBoxWidth,
 }: PostCountProps) {
   const [isHeartStatus, setIsHeartStatus] = useState(post.liked);
   const [heartCount, setHeartCount] = useState(post.likeCount);
@@ -92,7 +94,7 @@ export default function PostCount({
   return (
     <div className="flex justify-between py-4">
       <div className="flex gap-[44px] pr-[54px] text-[0.8125rem] font-bold text-darkPurple">
-        <div className="flex items-center ml-1">
+        <div className="ml-1 flex items-center">
           <button onClick={handleHeartClick}>
             {isHeartStatus ? (
               <PostHeartFillIcon className="mr-2 fill-red" />
@@ -102,16 +104,20 @@ export default function PostCount({
           </button>
           {heartCount}
         </div>
-        <div className="flex items-center">
+        <div
+          className={`flex items-center  ${imageBoxWidth < 500 ? 'text-purple' : 'text-darkPurple'}`}
+        >
           <PostChatIcon
-            className="mr-2 fill-darkPurple hover:fill-purple active:fill-darkPurple"
+            className={`mr-2 fill-darkPurple hover:fill-purple active:fill-darkPurple  
+            ${imageBoxWidth < 500 ? 'fill-purple' : 'fill-darkPurple'} `}
             onClick={toggleScroll}
           />
           {post.commentCount}
         </div>
         <div className="relative flex items-center" ref={menuRef}>
           <PostShareIcon
-            className={`mr-2 fill-darkPurple hover:fill-purple active:fill-darkPurple ${isMenuOpen ? 'fill-purple' : ''}`}
+            className={`mr-2 fill-darkPurple hover:fill-purple active:fill-darkPurple 
+            ${isMenuOpen ? 'fill-purple' : ''} `}
             onClick={handleShareClick}
           />
           {sharedCount}

--- a/app/(root)/(menubar-exist)/post/[postId]/components/mid/PostTags.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/components/mid/PostTags.tsx
@@ -9,7 +9,11 @@ interface PostTagsProps {
 }
 
 // 게시글 태그들
-export default function PostTags({ post, searchRecent, setSearchRecent }: PostTagsProps) {
+export default function PostTags({
+  post,
+  searchRecent,
+  setSearchRecent,
+}: PostTagsProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
   const startX = useRef(0);
@@ -51,7 +55,7 @@ export default function PostTags({ post, searchRecent, setSearchRecent }: PostTa
   // 해시태그 클릭 시 호출될 함수
   const handleTagClick = (tag: string) => {
     router.push(`/search/posts?keyword=${encodeURIComponent(tag)}`);
-    
+
     addSearchTermToRecent(tag);
   };
 
@@ -66,7 +70,7 @@ export default function PostTags({ post, searchRecent, setSearchRecent }: PostTa
 
   return (
     <div
-      className="relative 
+      className="
       overflow-x-hidden   xs:max-w-[300px]  sm:max-w-[400px] md:max-w-[500px] lg:max-w-[400px] 
       xl:max-w-[600px] 2xl:max-w-[800px]"
       onWheel={handleWheel}

--- a/app/(root)/(menubar-exist)/post/[postId]/layout.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/layout.tsx
@@ -7,11 +7,13 @@ export default function ArchiveLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <section className="contentSection h-screen flex-1 flex-col p-[20px] ">
-      <div className="contentContainer relative flex h-full w-full flex-1">
-        <div className="contentsDiv relative flex h-full w-full flex-col">
-          <SearchBar />
-          <NotLoginNotice>{children}</NotLoginNotice>
+    <section className="contentSection h-screen flex-1 flex-col p-[20px]">
+      <div className="contentContainer relative flex h-full w-full flex-1 ">
+        <div className="contentWrapper relative flex h-full w-full flex-col">
+          <NotLoginNotice>
+            <SearchBar />
+            {children}
+          </NotLoginNotice>
         </div>
       </div>
     </section>

--- a/app/(root)/(menubar-exist)/post/[postId]/page.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/page.tsx
@@ -57,7 +57,7 @@ export default function PostDetailPage() {
   const saved = userDetail.post?.saved ?? false;
 
   return (
-    <div className="hide-scrollbar overflow-auto ">
+    <div className="hide-scrollbar overflow-y-auto ">
       <TopContainer user={userDetail.post} postId={numericPostId} />
       <MidContainer
         post={userDetail.post}

--- a/app/(root)/(menubar-exist)/post/[postId]/page.tsx
+++ b/app/(root)/(menubar-exist)/post/[postId]/page.tsx
@@ -57,7 +57,7 @@ export default function PostDetailPage() {
   const saved = userDetail.post?.saved ?? false;
 
   return (
-    <div className="hide-scrollbar overflow-auto">
+    <div className="hide-scrollbar overflow-auto ">
       <TopContainer user={userDetail.post} postId={numericPostId} />
       <MidContainer
         post={userDetail.post}

--- a/app/(root)/(menubar-exist)/profile/[nickname]/page.tsx
+++ b/app/(root)/(menubar-exist)/profile/[nickname]/page.tsx
@@ -347,7 +347,7 @@ export default function ProfilePage() {
                 item.boundary == 'FOLLOW' && !isFollowState ? (
                   <div
                     key={index}
-                    className={` relative flex ${showType === 'album' ? 'flex-col mb-[10px]':""} ${showType === 'list' && 'h-[72px] items-center justify-center gap-[16px] pl-[25px] pr-[16px]'}`}
+                    className={` relative flex ${showType === 'album' ? 'mb-[10px] flex-col' : ''} ${showType === 'list' && 'h-[72px] items-center justify-center gap-[16px] pl-[25px] pr-[16px]'}`}
                     style={boxStyle}
                   >
                     <div
@@ -386,23 +386,23 @@ export default function ProfilePage() {
                   </div>
                 ) : (
                   <ArchiveBox
-                      key={index}
-                      showType={showType}
-                      archiveId={item.archiveId}
-                      photoId={index}
-                      photoUrl={item.archiveImgUrl}
-                      saved={false}
-                      createdDate={undefined}
-                      archiveName={item.archiveName}
-                      postCount={item.postCount}
-                      initialBoundary={item.boundary as 'ALL' | 'FOLLOW' | 'NONE'} 
-                      category={isCategory}                  
-                      />
+                    key={index}
+                    showType={showType}
+                    archiveId={item.archiveId}
+                    photoId={index}
+                    photoUrl={item.archiveImgUrl}
+                    saved={false}
+                    createdDate={undefined}
+                    archiveName={item.archiveName}
+                    postCount={item.postCount}
+                    initialBoundary={item.boundary as 'ALL' | 'FOLLOW' | 'NONE'}
+                    category={isCategory}
+                  />
                 ),
               )
             ) : (
               <div className="flex h-[300px] w-full items-center justify-center rounded-xl bg-lightGray">
-                <p className="text-darkModeGray text-[35px]">
+                <p className="text-[35px] text-darkModeGray">
                   표시할 아카이브가 없어요.
                 </p>
               </div>

--- a/app/(root)/(menubar-exist)/profile/[nickname]/page.tsx
+++ b/app/(root)/(menubar-exist)/profile/[nickname]/page.tsx
@@ -247,7 +247,7 @@ export default function ProfilePage() {
           </div>
         </div>
       )}
-      <div className={`sticky top-0 z-30 w-full bg-white`}>
+      <div className={`sticky top-0 z-[17] w-full bg-white`}>
         <div className="flex h-[54px] w-full items-center justify-between border-b-[1px] border-b-navBotSolidGray">
           <div className="categoryBar flex h-[66px] w-full flex-col items-start justify-between px-[5px]">
             <div className="categoryDiv flex h-[53px] w-full items-center justify-between border-b-[1px] border-navBotSolidGray">

--- a/app/(root)/(menubar-exist)/profile/archive/[archiveId]/page.tsx
+++ b/app/(root)/(menubar-exist)/profile/archive/[archiveId]/page.tsx
@@ -109,7 +109,7 @@ export default function ProfileArchive() {
             </p>
           </button>
         )}
-        <div className={`sticky top-0 z-30 w-full bg-white`}>
+        <div className={`sticky top-0 z-[17] w-full bg-white`}>
           <div className="flex h-[54px] w-full items-center justify-between border-b-[1px] border-b-navBotSolidGray">
             <div className="categoryBar flex h-[66px] w-full flex-col items-start justify-between px-[5px]">
               <div className="categoryDiv flex h-[53px] w-full items-center justify-between border-b-[1px] border-navBotSolidGray">
@@ -170,7 +170,7 @@ export default function ProfileArchive() {
               ))
             ) : (
               <div className="flex h-[300px] w-full items-center justify-center rounded-xl bg-lightGray">
-                <p className="text-darkModeGray text-[35px]">
+                <p className="text-[35px] text-darkModeGray">
                   표시할 게시물이 없어요.
                 </p>
               </div>

--- a/components/bars/search/SearchBar.tsx
+++ b/components/bars/search/SearchBar.tsx
@@ -311,9 +311,9 @@ export default function SearchBar() {
     : recommendedWords;
 
   return (
-    <div className="relative z-40 w-full">
+    <div className="relative z-[18] w-full">
       <form
-        className="relative z-30 flex items-center p-2"
+        className="relative z-[18] flex items-center p-2"
         onClick={(e) => e.stopPropagation()}
         onSubmit={handleFormSubmit}
       >

--- a/components/bars/search/SearchBar.tsx
+++ b/components/bars/search/SearchBar.tsx
@@ -88,22 +88,56 @@ export default function SearchBar() {
 
     try {
       const searchTerms = searchQuery.split(' ').filter(Boolean);
-      const lastSearchTerm = searchTerms[searchTerms.length - 1].toLowerCase(); // 마지막 단어만 검색
+      const lastSearchTerm = searchTerms[searchTerms.length - 1].toLowerCase();
 
-      // 이미 있는 태그 요청 X
-      const existingTags = tagResults.map((tag) => tag.tagName.toLowerCase());
-      if (existingTags.includes(lastSearchTerm)) {
-        return;
-      }
+      if (lastSearchTerm.startsWith('@')) {
+        // 닉네임 검색
+        const nicknameQuery = lastSearchTerm.slice(1); 
 
-      const newTagResults = await getTagSearchResults([lastSearchTerm]);
+        const userSearchResults = await getUserSearchResults(nicknameQuery); 
 
-      if (newTagResults && newTagResults.length > 0) {
-        setTagResults(newTagResults);
-        setSearchError('');
+        if (userSearchResults?.data && userSearchResults.data.length > 0) {
+          
+          const filteredUsers = userSearchResults.data.filter((user: any) =>
+            user.nickname.toLowerCase().includes(nicknameQuery),
+          );
+
+          if (filteredUsers.length > 0) {
+            setUserResults(filteredUsers); 
+            setSearchError(''); 
+          } else {
+            setUserResults([]);
+            if (showError) {
+              setSearchError(
+                `'${nicknameQuery}' 닉네임을 가진 사용자를 찾을 수 없습니다.`,
+              );
+            }
+          }
+        } else {
+          setUserResults([]);
+          if (showError) {
+            setSearchError(
+              `'${nicknameQuery}' 닉네임을 가진 사용자를 찾을 수 없습니다.`,
+            );
+          }
+        }
       } else {
-        if (showError) {
-          setSearchError(`'${lastSearchTerm}' 태그를 찾을 수 없습니다.`);
+        // 태그 검색 로직
+        const existingTags = tagResults.map((tag) => tag.tagName.toLowerCase());
+        if (existingTags.includes(lastSearchTerm)) {
+          return;
+        }
+
+        const newTagResults = await getTagSearchResults([lastSearchTerm]);
+
+        if (newTagResults && newTagResults.length > 0) {
+          setTagResults(newTagResults);
+          setSearchError('');
+        } else {
+          setTagResults([]);
+          if (showError) {
+            setSearchError(`'${lastSearchTerm}' 태그를 찾을 수 없습니다.`);
+          }
         }
       }
     } catch (error) {

--- a/components/boxes/ArchiveBox.tsx
+++ b/components/boxes/ArchiveBox.tsx
@@ -191,7 +191,7 @@ export default function ArchiveBox({
           height="20px"
           showGeneralAction={showGeneralAction}
           position="top-left"
-          className="z-30 p-2 "
+          className="z-10 p-2 "
         />
       )}
       {showType === 'album' && category === 'archive' && showGeneralAction && (

--- a/components/boxes/PostBox.tsx
+++ b/components/boxes/PostBox.tsx
@@ -149,7 +149,7 @@ function PostBox({
           active={isLoggedIn === 'loggedIn'}
         />
       </button>
-      <div className="absolute bottom-1 right-1 z-20 group-hover/button:border-purple">
+      <div className="absolute bottom-1 right-1 z-10 group-hover/button:border-purple">
         <PlusButton
           postId={postId}
           width="24px"

--- a/components/boxes/PostBox.tsx
+++ b/components/boxes/PostBox.tsx
@@ -140,7 +140,7 @@ function PostBox({
       </button>
       <button
         onClick={handleHeartClick}
-        className="z-9 absolute right-3 top-3 group-hover/button:border-purple"
+        className="z-10 absolute right-4 top-4 group-hover/button:border-purple"
       >
         <HeartButton
           width="21px"
@@ -149,7 +149,7 @@ function PostBox({
           active={isLoggedIn === 'loggedIn'}
         />
       </button>
-      <div className="absolute bottom-1 right-1 z-10 group-hover/button:border-purple">
+      <div className="absolute bottom-2 right-2 z-10 group-hover/button:border-purple">
         <PlusButton
           postId={postId}
           width="24px"
@@ -165,7 +165,7 @@ function PostBox({
           width="4px"
           height="20px"
           showGeneralAction={showGeneralAction}
-          className="absolute left-1 top-1 z-10 p-2 group-hover/button:border-purple"
+          className="absolute left-2 top-2 z-10 p-2 group-hover/button:border-purple"
           position="nothing"
         />
       )}

--- a/components/boxes/PostBox.tsx
+++ b/components/boxes/PostBox.tsx
@@ -105,23 +105,23 @@ function PostBox({
       className="group/button box relative flex items-center justify-center transition-all duration-500"
       style={{ width: postBoxWidths[layoutNum] }}
     >
-      {tempPost == true && (
-        <>
-          <div
-            onClick={handleTempClick}
-            className="absolute z-10 h-full w-full cursor-pointer bg-darkPurple opacity-60"
-          ></div>
-          <p className="z-10 text-center text-white">임시저장된 게시물</p>
-        </>
-      )}
       <button
         type="button"
-        className="absolute inset-0 z-0 overflow-hidden rounded-2xl border-[5px] 
-        border-transparent transition-all duration-500 group-hover/button:border-purple"
+        className="absolute inset-0 z-10 flex items-center justify-center 
+        overflow-hidden rounded-2xl border-[5px] border-transparent transition-all duration-500 group-hover/button:border-purple"
         onClick={(e) => {
           handlePostClick(e, postId);
         }}
       >
+        {tempPost == true && (
+          <>
+            <div
+              onClick={handleTempClick}
+              className="absolute z-10 h-full w-full cursor-pointer bg-darkPurple opacity-60"
+            ></div>
+            <p className="z-10 text-center text-white">임시저장된 게시물</p>
+          </>
+        )}
         {isPhoto && (
           <Image
             src={photoUrl}

--- a/components/buttons/option-menu/GeneralAction.tsx
+++ b/components/buttons/option-menu/GeneralAction.tsx
@@ -179,7 +179,7 @@ export default function GeneralAction({
   return (
     <div
       className={`text-14px-normal-dP absolute z-40 bg-white 
-    ${type !== 'archive' ? 'ml-5' : 'ml-2'} mt-3 w-[120px] whitespace-nowrap 
+    ${type !== 'archive' ? 'ml-7' : 'ml-2'} mt-3 w-[120px] whitespace-nowrap 
     rounded-xl bg-opacity-90 py-[13px] shadow-option-modal-shadow`}
     >
       {actionElements

--- a/components/buttons/option-menu/GeneralAction.tsx
+++ b/components/buttons/option-menu/GeneralAction.tsx
@@ -227,7 +227,7 @@ export default function GeneralAction({
         })}
       {!showOnlyShareButton && (
         <>
-          <hr className="mx-auto mt-[5px] w-[85%] border-darkGray" />
+          <hr className="mx-auto mt-[5px] w-[85%] border-darkGray " />
           <button
             className="group/item flex w-full items-center justify-center px-2 pt-[5px] hover:font-bold hover:text-red"
             onClick={(e) => handleDeleteClick(e, archiveId)}

--- a/components/buttons/option-menu/GeneralAction.tsx
+++ b/components/buttons/option-menu/GeneralAction.tsx
@@ -90,7 +90,6 @@ export default function GeneralAction({
     setShowDeleteModal(true);
 
     if (archiveId !== undefined) {
-      console.log('아카이브 삭제 모달이 열렸습니다.');
       dispatch(
         alarmModalData({
           type: 'two',
@@ -102,7 +101,6 @@ export default function GeneralAction({
         }),
       );
     } else if (postId !== undefined) {
-      console.log('포스트 삭제 모달이 열렸습니다.');
       dispatch(
         alarmModalData({
           type: 'two',
@@ -121,17 +119,13 @@ export default function GeneralAction({
   const handleDeleteConfirm = async () => {
     try {
       if (type === 'archive' && archiveId !== undefined) {
-        console.log('아카이브 삭제 확인 버튼 클릭됨');
         const response = await deleteArchiveCreate(archiveId);
         if (response) {
-          console.log('아카이브가 삭제되었습니다.');
           if (onDeleteClick) onDeleteClick(archiveId, 'archive');
         }
       } else if (type === 'post' && postId !== undefined) {
-        console.log('포스트 삭제 확인 버튼 클릭됨');
         const response = await deletePost(postId);
         if (response) {
-          console.log('게시물이 삭제되었습니다.');
           if (onDeleteClick) onDeleteClick(postId, 'post');
         }
       }

--- a/components/buttons/option-menu/GeneralSetting.tsx
+++ b/components/buttons/option-menu/GeneralSetting.tsx
@@ -62,7 +62,7 @@ export default function GeneralSetting({
 
   return (
     <div
-      className={`text-14px-normal-dP absolute z-10 mt-3  ${type !== 'archive' ? 'ml-5' : 'ml-2'} w-[120px] 
+      className={`text-14px-normal-dP absolute z-10 mt-3  ${type !== 'archive' ? 'ml-7' : 'ml-2'} w-[120px] 
     whitespace-nowrap rounded-xl bg-white bg-opacity-90 py-2 shadow-option-modal-shadow`}
     >
       <div className="flex items-center px-3 text-lg font-bold">

--- a/components/buttons/option-menu/GeneralShareMenu.tsx
+++ b/components/buttons/option-menu/GeneralShareMenu.tsx
@@ -29,7 +29,7 @@ export default function GeneralShareMenu({
 
   return (
     <div
-      className={`text-14px-normal-dP absolute z-10 ${type === 'archive' ? 'ml-2' : 'ml-5'} mt-3 w-[120px] 
+      className={`text-14px-normal-dP absolute z-10 ${type === 'archive' ? 'ml-2' : 'ml-7'} mt-3 w-[120px] 
     whitespace-nowrap rounded-xl bg-white bg-opacity-90 pt-2 shadow-option-modal-shadow`}
     >
       {showBackButton && (

--- a/components/modal/common/AlarmModal.tsx
+++ b/components/modal/common/AlarmModal.tsx
@@ -35,7 +35,7 @@ export default function AlarmModal({ onConfirm, onCancel }: AlarmModalProps) {
     : '';
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-modalBackgroundColor">
+    <div className="fixed inset-0 z-[99] flex items-center justify-center bg-modalBackgroundColor">
       <div className="rounded-lg bg-white opacity-85">
         <div className="px-[33px] py-11 text-center">
           {/* 삭제 관련 메시지 */}

--- a/components/modal/common/commonModalLayout.tsx
+++ b/components/modal/common/commonModalLayout.tsx
@@ -21,7 +21,7 @@ export default function CommonModalLayout() {
   return (
     <div className={`commonModal ${!isCommonModalShow && 'hidden'} absolute w-full h-full
       z-50 flex items-center justify-center pointer-events-auto
-      bottom-0 right-0 bg-modalBackgroundColor`}>
+      bottom-0 right-0 `}>
       {
         whichCommonModal === 'login' &&
         <LoginModal />

--- a/components/modal/message/MessageModal.tsx
+++ b/components/modal/message/MessageModal.tsx
@@ -80,7 +80,7 @@ export default function MessageModal() {
   );
 
   return (
-    <div className={`${path === '/sign-up' && 'hidden'} ${isLoggedIn === 'pending' && 'hidden'} ${isLoggedIn === 'loggedOut' && 'hidden'} messageModal absolute w-full h-full z-40 flex items-center justify-end pointer-events-none bottom-0 right-0`}>
+    <div className={`${path === '/sign-up' && 'hidden'} ${isLoggedIn === 'pending' && 'hidden'} ${isLoggedIn === 'loggedOut' && 'hidden'} messageModal absolute w-full h-full z-[19] flex items-center justify-end pointer-events-none bottom-0 right-0`}>
       <div
         className='absolute'
         style={{ bottom: `${isChatModalShow ? '620px' : '100px'}`, right: `${isChatModalShow ? '380px' : '100px'}` 


### PR DESCRIPTION
**1. 디테일 게시물 페이지**
- 게시물 삭제시 마이페이지로 이동 로직 추가
- 모달 켜져있을 시 스크롤 방지
- css 구조 변경(화면 크기 변경시 컨텐츠들이 너무 움직이는 문제)
- 댓글 영역 보일때 채팅 아이콘 purple로 유지

**2. z-index 대폭조정** 
- 디테일 게시물에서 모달열시 검색바, 채팅바 등등의 zindex가 모달에 안가려져서 조정했습니다
- 조정한 부분 : 검색바, 채팅바, (마이페이지, 프로필페이지 내의) categorybar, 메세지모달, (PostBox내의) 플러스버튼, (ArchiveBox내의) 토글버튼
=> ⭐️⭐️본인 해당하는 부분 **_문제 없는 지 확인_** 바람⭐️⭐️
- !! z-index 문제 발견시 말씀해주세요 !!
- [z-index 대폭조정 커밋코드](https://github.com/nail-dp-dev/nail-dp-dev-nextjs14/pull/143/commits/c404f0e110ccdca34b39d6971740dc2f6e8023b2)

**3. 닉네임 연관검색 가능하게 변경**
- 태그 연관검색은 문제 생겨서 백엔드와 조정 중

**4. PostBox 토글, 하트, 플러스 버튼 위치 조정**